### PR TITLE
feat: entitlements store and purchase guards

### DIFF
--- a/lib/core/entitlements.dart
+++ b/lib/core/entitlements.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Features that may require an entitlement to access.
+enum Feature { capture, ocr, exportPdf }
+
+class EntitlementsStore extends AsyncNotifier<Set<Feature>> {
+  static const _fileName = 'entitlements.json';
+
+  @override
+  Future<Set<Feature>> build() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/$_fileName');
+    if (await file.exists()) {
+      final data = jsonDecode(await file.readAsString()) as List<dynamic>;
+      return data.map((e) => Feature.values.byName(e as String)).toSet();
+    }
+    return <Feature>{};
+  }
+
+  Future<void> _save(Set<Feature> entitlements) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/$_fileName');
+    await file.writeAsString(
+      jsonEncode(entitlements.map((e) => e.name).toList()),
+    );
+  }
+
+  Future<void> grant(Feature feature) async {
+    final newState = {...(state.value ?? {}), feature};
+    state = AsyncData(newState);
+    await _save(newState);
+  }
+
+  Future<void> revoke(Feature feature) async {
+    final newState = {...(state.value ?? {})}..remove(feature);
+    state = AsyncData(newState);
+    await _save(newState);
+  }
+
+  bool isEntitled(Feature feature) => state.value?.contains(feature) ?? false;
+}
+
+final entitlementsProvider =
+    AsyncNotifierProvider<EntitlementsStore, Set<Feature>>(EntitlementsStore.new);
+
+final featureUnlockedProvider = Provider.family<bool, Feature>((ref, feature) {
+  final entitlements = ref.watch(entitlementsProvider).maybeWhen(
+        data: (value) => value,
+        orElse: () => <Feature>{},
+      );
+  return entitlements.contains(feature);
+});

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -1,19 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:offline_pdf_document_scanner/core/entitlements.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends ConsumerWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final canCapture = ref.watch(featureUnlockedProvider(Feature.capture));
+
     return Scaffold(
       appBar: AppBar(title: const Text('Offline PDF Scanner')),
       body: const Center(child: Text('Recent documents will appear here.')),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => context.push('/capture'),
-        label: const Text('New Scan'),
-        icon: const Icon(Icons.camera_alt_outlined),
-      ),
+      floatingActionButton: canCapture
+          ? FloatingActionButton.extended(
+              onPressed: () => context.push('/capture'),
+              label: const Text('New Scan'),
+              icon: const Icon(Icons.camera_alt_outlined),
+            )
+          : null,
     );
   }
 }

--- a/test/entitlements_store_test.dart
+++ b/test/entitlements_store_test.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:offline_pdf_document_scanner/core/entitlements.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+
+class _FakePathProvider extends PathProviderPlatform {
+  @override
+  Future<String?> getApplicationDocumentsPath() async {
+    final dir = await Directory.systemTemp.createTemp();
+    return dir.path;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    PathProviderPlatform.instance = _FakePathProvider();
+  });
+
+  test('grants and revokes features', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await container.read(entitlementsProvider.future);
+    final store = container.read(entitlementsProvider.notifier);
+
+    await store.grant(Feature.capture);
+    expect(container.read(entitlementsProvider).value, {Feature.capture});
+
+    await store.revoke(Feature.capture);
+    expect(container.read(entitlementsProvider).value, <Feature>{});
+  });
+}


### PR DESCRIPTION
## Summary
- add local entitlements store with persistence
- guard capture flow behind entitlement
- test entitlements store behavior

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca3b9d6c483238d3c6357ccc6eac3