### PR TITLE
feat: banner ads integrations, placements, personalization toggle (free only)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-xxxxxxxxxxxxxxxx~yyyyyyyyyy" />
+        <!-- TODO(owner): replace -->
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,10 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>GADApplicationIdentifier</key>
+        <string>ca-app-pub-xxxxxxxxxxxxxxxx/~zzzzzzzzzz</string>
+        <!-- TODO(owner): replace -->
 </dict>
 </plist>

--- a/lib/features/ads/ads_config.dart
+++ b/lib/features/ads/ads_config.dart
@@ -1,0 +1,13 @@
+/// Ad unit IDs for banners.
+class AdsConfig {
+  // TODO(owner): replace with real unit IDs; keep test IDs for development
+  static const androidBanner = 'ca-app-pub-3940256099942544/6300978111';
+  static const iosBanner = 'ca-app-pub-3940256099942544/2934735716';
+}
+
+/// Areas where ads may appear.
+enum AdsArea { home, documents }
+
+/// Helper to declare where ads are allowed based on route name.
+bool adsAllowedForRoute(String routeName) =>
+    routeName == '/home' || routeName == '/documents';

--- a/lib/features/ads/ads_prefs.dart
+++ b/lib/features/ads/ads_prefs.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AdsPrefs {
+  AdsPrefs({this.personalizedAds = true});
+  final bool personalizedAds;
+
+  AdsPrefs copyWith({bool? personalizedAds}) =>
+      AdsPrefs(personalizedAds: personalizedAds ?? this.personalizedAds);
+}
+
+class AdsPrefsNotifier extends StateNotifier<AdsPrefs> {
+  AdsPrefsNotifier() : super(AdsPrefs()) {
+    _load();
+  }
+
+  static const _keyPersonalized = 'ads_personalized';
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getBool(_keyPersonalized) ?? true;
+    state = AdsPrefs(personalizedAds: value);
+  }
+
+  Future<void> setPersonalizedAds(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_keyPersonalized, value);
+    state = AdsPrefs(personalizedAds: value);
+  }
+}
+
+final adsPrefsProvider =
+    StateNotifierProvider<AdsPrefsNotifier, AdsPrefs>(AdsPrefsNotifier.new);

--- a/lib/features/ads/ads_service.dart
+++ b/lib/features/ads/ads_service.dart
@@ -1,0 +1,100 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+
+import 'ads_config.dart';
+
+/// Provides access to advertising services.
+final adsServiceProvider = Provider<AdsService>((ref) => AdsService(ref));
+
+class AdsService {
+  AdsService(this.ref);
+  final Ref ref;
+  bool _initialized = false;
+
+  Future<void> init() async {
+    if (_initialized) return;
+    MobileAds.instance.initialize();
+    _initialized = true;
+  }
+
+  /// Builds a banner widget or [SizedBox.shrink] if not allowed/available.
+  /// [personalized] toggles nonPersonalizedAds in [AdRequest].
+  Widget buildBanner({required BuildContext context, required bool personalized}) {
+    if (!_initialized) return const SizedBox.shrink();
+    final adSize = AdSize.banner;
+    final request = AdRequest(
+      nonPersonalizedAds: !personalized,
+    );
+    return AdWidgetBanner(
+      adUnitId: Platform.isAndroid ? AdsConfig.androidBanner : AdsConfig.iosBanner,
+      size: adSize,
+      request: request,
+    );
+  }
+}
+
+class AdWidgetBanner extends StatefulWidget {
+  const AdWidgetBanner({
+    super.key,
+    required this.adUnitId,
+    required this.size,
+    required this.request,
+  });
+
+  final String adUnitId;
+  final AdSize size;
+  final AdRequest request;
+
+  @override
+  State<AdWidgetBanner> createState() => _AdWidgetBannerState();
+}
+
+class _AdWidgetBannerState extends State<AdWidgetBanner> {
+  BannerAd? _banner;
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _banner = BannerAd(
+      adUnitId: widget.adUnitId,
+      size: widget.size,
+      request: widget.request,
+      listener: BannerAdListener(
+        onAdLoaded: (ad) {
+          setState(() {
+            _loaded = true;
+          });
+        },
+        onAdFailedToLoad: (ad, error) {
+          ad.dispose();
+          setState(() {
+            _banner = null;
+            _loaded = false;
+          });
+        },
+      ),
+    )..load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_loaded || _banner == null) {
+      return const SizedBox(height: 0);
+    }
+    return SizedBox(
+      width: _banner!.size.width.toDouble(),
+      height: _banner!.size.height.toDouble(),
+      child: AdWidget(ad: _banner!),
+    );
+  }
+
+  @override
+  void dispose() {
+    _banner?.dispose();
+    super.dispose();
+  }
+}

--- a/lib/features/ads/ads_widgets.dart
+++ b/lib/features/ads/ads_widgets.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'ads_config.dart';
+import 'ads_prefs.dart';
+import 'ads_service.dart';
+import '../iap/entitlements.dart';
+
+class BannerHost extends ConsumerWidget {
+  const BannerHost({super.key, required this.routeName});
+
+  final String routeName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!adsAllowedForRoute(routeName)) {
+      return const SizedBox.shrink();
+    }
+
+    final entitlements = ref
+        .watch(iapEntitlementsProvider)
+        .maybeWhen(data: (e) => e, orElse: () => <IapEntitlement>{});
+    if (entitlements.contains(IapEntitlement.premium)) {
+      return const SizedBox.shrink();
+    }
+
+    final viewInsets = MediaQuery.of(context).viewInsets;
+    if (viewInsets.bottom > 0) {
+      return const SizedBox.shrink();
+    }
+
+    final height = MediaQuery.of(context).size.height;
+    if (height < 480) {
+      return const SizedBox.shrink();
+    }
+
+    final prefs = ref.watch(adsPrefsProvider);
+    final service = ref.watch(adsServiceProvider);
+    service.init();
+
+    return service.buildBanner(
+      context: context,
+      personalized: prefs.personalizedAds,
+    );
+  }
+}

--- a/lib/features/documents/presentation/list_page.dart
+++ b/lib/features/documents/presentation/list_page.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:offline_pdf_document_scanner/features/ads/ads_widgets.dart';
+
+class DocumentsListPage extends ConsumerWidget {
+  const DocumentsListPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Documents')),
+      body: const Center(child: Text('Your documents will appear here.')),
+      bottomNavigationBar: const BannerHost(routeName: '/documents'),
+    );
+  }
+}

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:offline_pdf_document_scanner/core/entitlements.dart';
+import 'package:offline_pdf_document_scanner/features/ads/ads_widgets.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});
@@ -13,6 +14,7 @@ class HomePage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Offline PDF Scanner')),
       body: const Center(child: Text('Recent documents will appear here.')),
+      bottomNavigationBar: const BannerHost(routeName: '/home'),
       floatingActionButton: canCapture
           ? FloatingActionButton.extended(
               onPressed: () => context.push('/capture'),

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -2,15 +2,18 @@ import 'package:go_router/go_router.dart';
 
 import 'package:offline_pdf_document_scanner/features/capture/presentation/capture_page.dart';
 import 'package:offline_pdf_document_scanner/features/home/presentation/home_page.dart';
+import 'package:offline_pdf_document_scanner/features/documents/presentation/list_page.dart';
 import 'package:offline_pdf_document_scanner/features/iap/paywall_page.dart';
 import 'package:offline_pdf_document_scanner/features/pdf/presentation/preview_page.dart';
 
 GoRouter buildRouter() => GoRouter(
-  routes: [
-    GoRoute(path: '/', builder: (c, s) => const HomePage()),
-    GoRoute(path: '/capture', builder: (c, s) => const CapturePage()),
-    GoRoute(path: '/preview', builder: (c, s) => const PreviewPage()),
-    GoRoute(path: '/paywall', builder: (c, s) => const PaywallPage()),
-  ],
-  initialLocation: '/',
-);
+      routes: [
+        GoRoute(path: '/', redirect: (_, __) => '/home'),
+        GoRoute(path: '/home', builder: (c, s) => const HomePage()),
+        GoRoute(path: '/documents', builder: (c, s) => const DocumentsListPage()),
+        GoRoute(path: '/capture', builder: (c, s) => const CapturePage()),
+        GoRoute(path: '/preview', builder: (c, s) => const PreviewPage()),
+        GoRoute(path: '/paywall', builder: (c, s) => const PaywallPage()),
+      ],
+      initialLocation: '/home',
+    );

--- a/lib/settings/settings_page.dart
+++ b/lib/settings/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:offline_pdf_document_scanner/features/iap/iap_service.dart';
+import 'package:offline_pdf_document_scanner/features/ads/ads_prefs.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({super.key});
@@ -10,11 +11,23 @@ class SettingsPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final service = ref.watch(iapServiceProvider);
+    final adsPrefs = ref.watch(adsPrefsProvider);
+    final adsPrefsNotifier = ref.read(adsPrefsProvider.notifier);
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
+          Card(
+            child: SwitchListTile(
+              title: const Text('Personalized ads'),
+              subtitle: const Text(
+                'You can turn off personalized ads. You may still see ads.',
+              ),
+              value: adsPrefs.personalizedAds,
+              onChanged: adsPrefsNotifier.setPersonalizedAds,
+            ),
+          ),
           Card(
             child: Column(
               children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -367,6 +367,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "16.1.0"
+  google_mobile_ads:
+    dependency: "direct main"
+    description:
+      name: google_mobile_ads
+      sha256: "f07d4e2ebf56181e8dd18ee810607e84aeac8add5251bb44c1c886af47ff021a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
   golden_toolkit:
     dependency: "direct dev"
     description:
@@ -823,6 +831,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "746e5369a43170c25816cc472ee016d3a66bc13fcf430c0bc41ad7b4b2922051"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,8 @@ dependencies:
   json_annotation: ^4.9.0
   in_app_purchase: ^3.2.3
   in_app_purchase_platform_interface: ^1.4.0
+  google_mobile_ads: ^5.0.0
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:

--- a/test/ads/ads_premium_hides_test.dart
+++ b/test/ads/ads_premium_hides_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:offline_pdf_document_scanner/features/ads/ads_widgets.dart';
+import 'package:offline_pdf_document_scanner/features/ads/ads_service.dart';
+import 'package:offline_pdf_document_scanner/features/iap/entitlements.dart';
+
+void main() {
+  testWidgets('Premium users see no ads', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adsServiceProvider.overrideWith((ref) => _FakeAdsService(ref)),
+          iapEntitlementsProvider.overrideWith(_premiumEntitlements),
+        ],
+        child: const MaterialApp(home: BannerHost(routeName: '/home')),
+      ),
+    );
+    await tester.pump();
+    expect(find.byKey(const Key('test-ad')), findsNothing);
+  });
+}
+
+class _FakeAdsService extends AdsService {
+  _FakeAdsService(super.ref);
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Widget buildBanner({required BuildContext context, required bool personalized}) {
+    return Container(key: const Key('test-ad'), height: 50);
+  }
+}
+
+IapEntitlementsStore _premiumEntitlements() => _PremiumEntitlements();
+
+class _PremiumEntitlements extends IapEntitlementsStore {
+  @override
+  Future<Set<IapEntitlement>> build() async => {IapEntitlement.premium};
+}

--- a/test/ads/ads_route_exclusion_test.dart
+++ b/test/ads/ads_route_exclusion_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:offline_pdf_document_scanner/features/ads/ads_widgets.dart';
+import 'package:offline_pdf_document_scanner/features/ads/ads_service.dart';
+import 'package:offline_pdf_document_scanner/features/iap/entitlements.dart';
+
+void main() {
+  const excluded = ['/capture', '/crop', '/filter', '/annotate', '/export'];
+  for (final route in excluded) {
+    testWidgets('No banner on route '+route, (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            adsServiceProvider.overrideWith((ref) => _FakeAdsService(ref)),
+            iapEntitlementsProvider.overrideWith(_fakeEntitlements),
+          ],
+          child: MaterialApp(home: BannerHost(routeName: route)),
+        ),
+      );
+      await tester.pump();
+      expect(find.byKey(const Key('test-ad')), findsNothing);
+    });
+  }
+}
+
+class _FakeAdsService extends AdsService {
+  _FakeAdsService(super.ref);
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Widget buildBanner({required BuildContext context, required bool personalized}) {
+    return Container(key: const Key('test-ad'), height: 50);
+  }
+}
+
+IapEntitlementsStore _fakeEntitlements() => _FakeEntitlements();
+
+class _FakeEntitlements extends IapEntitlementsStore {
+  @override
+  Future<Set<IapEntitlement>> build() async => <IapEntitlement>{};
+}

--- a/test/ads/ads_settings_persistence_test.dart
+++ b/test/ads/ads_settings_persistence_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:offline_pdf_document_scanner/features/ads/ads_prefs.dart';
+
+void main() {
+  test('personalized ads preference persists', () async {
+    SharedPreferences.setMockInitialValues({});
+    final container = ProviderContainer();
+    await Future.delayed(Duration.zero);
+    expect(container.read(adsPrefsProvider).personalizedAds, isTrue);
+
+    await container.read(adsPrefsProvider.notifier).setPersonalizedAds(false);
+    await Future.delayed(Duration.zero);
+    expect(container.read(adsPrefsProvider).personalizedAds, isFalse);
+
+    final container2 = ProviderContainer();
+    await Future.delayed(Duration.zero);
+    expect(container2.read(adsPrefsProvider).personalizedAds, isFalse);
+  });
+}

--- a/test/ads/ads_widget_visibility_test.dart
+++ b/test/ads/ads_widget_visibility_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:offline_pdf_document_scanner/features/ads/ads_widgets.dart';
+import 'package:offline_pdf_document_scanner/features/ads/ads_service.dart';
+import 'package:offline_pdf_document_scanner/features/iap/entitlements.dart';
+
+void main() {
+  testWidgets('BannerHost renders on home route', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adsServiceProvider.overrideWith((ref) => _FakeAdsService(ref)),
+          iapEntitlementsProvider.overrideWith(_fakeEntitlements),
+        ],
+        child: const MaterialApp(home: BannerHost(routeName: '/home')),
+      ),
+    );
+    await tester.pump();
+    expect(find.byKey(const Key('test-ad')), findsOneWidget);
+  });
+
+  testWidgets('BannerHost hidden on disallowed route', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adsServiceProvider.overrideWith((ref) => _FakeAdsService(ref)),
+          iapEntitlementsProvider.overrideWith(_fakeEntitlements),
+        ],
+        child: const MaterialApp(home: BannerHost(routeName: '/capture')),
+      ),
+    );
+    await tester.pump();
+    expect(find.byKey(const Key('test-ad')), findsNothing);
+  });
+}
+
+class _FakeAdsService extends AdsService {
+  _FakeAdsService(super.ref);
+
+  @override
+  Future<void> init() async {}
+
+  @override
+  Widget buildBanner({required BuildContext context, required bool personalized}) {
+    return Container(key: const Key('test-ad'), height: 50);
+  }
+}
+
+IapEntitlementsStore _fakeEntitlements() => _FakeEntitlements();
+
+class _FakeEntitlements extends IapEntitlementsStore {
+  @override
+  Future<Set<IapEntitlement>> build() async => <IapEntitlement>{};
+}


### PR DESCRIPTION
## Summary
- integrate Google Mobile Ads banner service with route gating and personalization toggle
- add BannerHost to Home and Documents pages, respecting premium entitlements and route exclusions
- add "Personalized ads" setting backed by SharedPreferences

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dcb18286c8323b72881e4329417eb